### PR TITLE
Convert cooljeanius/gvpe-2.25 to GitHub Actions

### DIFF
--- a/.github/workflows/gvpe-2.25.yml
+++ b/.github/workflows/gvpe-2.25.yml
@@ -1,0 +1,24 @@
+name: cooljeanius/gvpe-2.25
+on:
+  push:
+    branches:
+    - "**/*"
+  pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v3.5.0
+#     # 'Transformers::TravisCI::Scripts::Dependencies' dependencies are currently unsupported
+#     # 'compiler' was not transformed because there is no suitable equivalent in GitHub Actions
+    - run: sudo apt-get install texinfo
+    - run: "./configure && make && make check"
+    strategy:
+      matrix:
+        compiler:
+        - clang
+        - gcc


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/cooljeanius/gvpe-2.25) :tada: