### PR TITLE
Re-convert cooljeanius/gvpe-2.25 to GitHub Actions

### DIFF
--- a/.github/workflows/gvpe-2.25.yml
+++ b/.github/workflows/gvpe-2.25.yml
@@ -4,9 +4,6 @@ on:
     branches:
     - "**/*"
   pull_request:
-concurrency:
-#   # This item has no matching transformer
-#   maximum_number_of_builds: 0
 jobs:
   test:
     runs-on: ubuntu-16.04

--- a/.github/workflows/gvpe-2.25.yml
+++ b/.github/workflows/gvpe-2.25.yml
@@ -4,12 +4,15 @@ on:
     branches:
     - "**/*"
   pull_request:
+concurrency:
+#   # This item has no matching transformer
+#   maximum_number_of_builds: 0
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - name: checkout
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v4.0.0
 #     # 'Transformers::TravisCI::Scripts::Dependencies' dependencies are currently unsupported
 #     # 'compiler' was not transformed because there is no suitable equivalent in GitHub Actions
     - run: sudo apt-get install texinfo


### PR DESCRIPTION
Pipeline migrated from [Travis CI](https://travis-ci.com/cooljeanius/gvpe-2.25) :tada: (again)