### PR TITLE
Fix code scanning alert #4: Use of a cryptographic algorithm with insufficient key size

### DIFF
--- a/src/gvpectrl.C
+++ b/src/gvpectrl.C
@@ -179,7 +179,7 @@ parse_options(int argc, char **argv, char **envp)
                 break;
 
             case 'g':		/* generate public/private keypair */
-                generate_keys = RSA_KEYBITS;
+                generate_keys = 2048; // Updated to use a secure key size
                 break;
 
             case 's':


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/gvpe-2.25/security/code-scanning/4](https://github.com/cooljeanius/gvpe-2.25/security/code-scanning/4)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
